### PR TITLE
horizontally center the logo for tablet and mobile

### DIFF
--- a/examples/components/nav-bar.hbs
+++ b/examples/components/nav-bar.hbs
@@ -4,9 +4,11 @@
          <span class="hamburger-parent">
           <i class="hamburger fas fa-bars"></i>
         </span>
-         <span>
+        <span class="logo-parent">
+             <a class=" logo-link">
                 <img src="images/online-logo.png" alt="online-logo" class="nav-logo pointer">
-         </span>
+            </a>         
+        </span>
          <ul class="nav-list">
              <li class="nav-items pointer">
                  About us

--- a/sass/styles/elements/elements.navigation.scss
+++ b/sass/styles/elements/elements.navigation.scss
@@ -47,3 +47,7 @@ nav {
 .active {
   color: $button-gradient;
 }
+
+.logo-parent{
+  text-align : center;
+}

--- a/sass/styles/media-query/media.home.scss
+++ b/sass/styles/media-query/media.home.scss
@@ -33,4 +33,11 @@
 
 .testclass{
   width: 100px;
+} 
+
+@media all and (max-width: 875px){
+  .logo-link{
+    display: inline-block;
+    min-width: 80%;
+  }
 }


### PR DESCRIPTION
#131 
Just add logo-parent class to parent span of link/image and activeclass='logo-link' to link.