### PR TITLE
Fix: displaced nav-bar due to notify-dot

### DIFF
--- a/sass/styles/elements/elements.navigation.scss
+++ b/sass/styles/elements/elements.navigation.scss
@@ -40,6 +40,12 @@ nav {
   color: $navLink;
 }
 
+.pointer {
+  .notify-dot {
+    position: absolute;   
+  }
+}
+
 .active {
   color: $button-gradient;
 }


### PR DESCRIPTION
Before: (Downward displaced nav bar)
![screen shot 2018-06-01 at 9 06 17 pm](https://user-images.githubusercontent.com/8109774/40849484-af96bb9c-65df-11e8-8ea5-a715eae103ec.png)

After:
![screen shot 2018-06-01 at 9 06 10 pm](https://user-images.githubusercontent.com/8109774/40849488-b353255e-65df-11e8-89a5-1d278ffbf608.png)
