### PR TITLE
Aligned profile image on navbar

### DIFF
--- a/sass/styles/objects/o-nav-layout/o-nav-layout.scss
+++ b/sass/styles/objects/o-nav-layout/o-nav-layout.scss
@@ -21,7 +21,7 @@
 .main-nav{
   .round-img{
     @include dimensions(60px, 60px);
-    
+    padding: 3px 30px 3px 0;
     float: right;
     cursor: pointer;
   }

--- a/sass/styles/objects/o-nav-layout/o-nav-layout.scss
+++ b/sass/styles/objects/o-nav-layout/o-nav-layout.scss
@@ -21,7 +21,7 @@
 .main-nav{
   .round-img{
     @include dimensions(60px, 60px);
-    padding: 3px 30px 3px 0;
+    @include padding-mixin(3px, 30px, 3px, 0);
     float: right;
     cursor: pointer;
   }


### PR DESCRIPTION
![screen shot 2018-07-08 at 10 44 42 am](https://user-images.githubusercontent.com/29275810/42417115-464e22a2-829e-11e8-8320-dedafaf4409d.png)

The nav image would look better if it's within the bounds of the profile card below it, as it is here